### PR TITLE
Parse protobuf data before executing submsg

### DIFF
--- a/packages/multi-test/src/multi/test_helpers/contracts/echo.rs
+++ b/packages/multi-test/src/multi/test_helpers/contracts/echo.rs
@@ -96,29 +96,13 @@ where
 {
     let res = Response::new();
     if let Reply {
-        id,
+        id: _,
         result: SubMsgResult::Ok(SubMsgResponse {
             data: Some(data), ..
         }),
     } = msg
     {
-        // We parse out the WasmMsg::Execute wrapper...
-        // TODO: Handle all of Execute, Instantiate, and BankMsg replies differently.
-        let parsed_data = if id < EXECUTE_REPLY_BASE_ID {
-            parse_instantiate_response_data(data.as_slice())
-                .map_err(|e| StdError::generic_err(e.to_string()))?
-                .data
-        } else {
-            parse_execute_response_data(data.as_slice())
-                .map_err(|e| StdError::generic_err(e.to_string()))?
-                .data
-        };
-
-        if let Some(data) = parsed_data {
-            Ok(res.set_data(data))
-        } else {
-            Ok(res)
-        }
+        Ok(res.set_data(data))
     } else {
         Ok(res)
     }

--- a/packages/multi-test/src/multi/wasm.rs
+++ b/packages/multi-test/src/multi/wasm.rs
@@ -37,6 +37,7 @@ use cosmwasm_std::{
 use nanoid::nanoid;
 use prost::Message;
 use schemars::JsonSchema;
+use secret_utils::parse_execute_response_data;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
@@ -571,11 +572,18 @@ where
         // call reply if meaningful
         if let Ok(mut r) = res {
             if matches!(reply_on, ReplyOn::Always | ReplyOn::Success) {
+                let data: Option<Binary> = if let Some(b) = r.data {
+                    let parsed = parse_execute_response_data(b.as_slice())?;
+                    parsed.data
+                } else {
+                    None
+                };
+
                 let reply = Reply {
                     id,
                     result: SubMsgResult::Ok(SubMsgResponse {
                         events: r.events.clone(),
-                        data: r.data,
+                        data,
                     }),
                 };
                 // do reply and combine it with the original response


### PR DESCRIPTION
Parses previous msg's response data before passing it to submsg for execution. Updates the test contract 'Echo' with matching changes to keep all tests passing.